### PR TITLE
Add support for SchoolSoft news/messages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 testkeys.py
 *.swp
 __pycache__
+.idea
+venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bs4
+requests


### PR DESCRIPTION
Hi,

Thanks for the foundation on the SchoolSoft API!

Here is an addition to extract the news part. I think it will work well in most cases. There's a known limitation that it only handles a single attachment; the SchoolSoft web page looks like it could support multiple but I have no such data to test with. Also, relative URLs should probably be rewritten to absolute URLs to be more useful.